### PR TITLE
Fix cross-platform build issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,9 @@
 // swift-tools-version:5.9
 import PackageDescription
 
+// The share extension relies on UIKit and therefore can't build on non-Darwin
+// platforms. We conditionally include that target only when UIKit is available.
+#if os(iOS)
 let package = Package(
     name: "NexusFiles",
     platforms: [
@@ -26,3 +29,26 @@ let package = Package(
         )
     ]
 )
+#else
+let package = Package(
+    name: "NexusFiles",
+    platforms: [
+        .iOS(.v17)
+    ],
+    products: [
+        .library(name: "NexusFiles", targets: ["NexusFiles"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/damuellen/xlsxwriter.swift", from: "1.0.0")
+    ],
+    targets: [
+        .target(
+            name: "NexusFiles",
+            dependencies: [
+                .product(name: "xlsxwriter", package: "xlsxwriter.swift")
+            ],
+            path: "Sources"
+        )
+    ]
+)
+#endif

--- a/Sources/Utilities/ExcelExporter.swift
+++ b/Sources/Utilities/ExcelExporter.swift
@@ -1,6 +1,5 @@
 import Foundation
 import xlsxwriter
-import UIKit
 
 struct ExcelExporter {
     static func isoDateString(_ date: Date = Date()) -> String {


### PR DESCRIPTION
## Summary
- avoid importing UIKit in Excel exporter
- compile share extension only on iOS platforms

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68402d433f808331b6acc0549b716e2f