### PR TITLE
Improve category persistence and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Building on Linux requires the `libxlsxwriter` development package. However, the
 
 The exported Excel files are saved to the app's documents directory. Each file name includes an ISO‑8601 timestamp for easy organization. Files can be shared directly from the app using the standard iOS share sheet.
 
+### Persistent categories
+
+Categories created on the Home screen are saved as JSON in the app's documents directory. They are automatically sorted alphabetically whenever they're modified.
+
 ## Contributing
 
 Contributions are welcome. Please open issues or pull requests on GitHub. All code is expected to follow Swift style conventions and include clear commit messages.

--- a/Sources/Utilities/FileStorage.swift
+++ b/Sources/Utilities/FileStorage.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Simple utility for loading and saving Codable values to disk.
+struct FileStorage {
+    /// Load a Codable value from a file URL.
+    static func load<T: Decodable>(_ type: T.Type, from url: URL) throws -> T {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    /// Save a Codable value to a file URL.
+    static func save<T: Encodable>(_ value: T, to url: URL) throws {
+        let data = try JSONEncoder().encode(value)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
+    }
+}


### PR DESCRIPTION
## Summary
- add `FileStorage` utility for consistent JSON read/write
- refactor `HomeViewModel` to use new helper and sort categories
- document category persistence in README

## Testing
- `swift build` *(fails: 'xlsxwriter.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407a619a908331ba5082d8e57dd921