### PR TITLE
Implement macOS target and enhanced share extension

### DIFF
--- a/MacApp/NexusFilesMacApp.swift
+++ b/MacApp/NexusFilesMacApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+import NexusFiles
+
+@main
+struct NexusFilesMacApp: App {
+    var body: some Scene {
+        WindowGroup {
+            HomeView()
+        }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,29 +1,37 @@
 // swift-tools-version:5.9
 import PackageDescription
 
-// The share extension relies on UIKit and therefore can't build on non-Darwin
-// platforms. We conditionally include that target only when UIKit is available.
 #if os(iOS)
 let package = Package(
     name: "NexusFiles",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17)
+        .iOS(.v17), .macOS(.v14)
     ],
     products: [
-        .library(name: "NexusFiles", targets: ["NexusFiles"])
+        .library(name: "NexusFiles", targets: ["NexusFiles"]),
+        .executable(name: "NexusFilesMac", targets: ["NexusFilesMac"])
     ],
     dependencies: [
-        .package(url: "https://github.com/damuellen/xlsxwriter.swift", from: "1.0.0")
+        .package(url: "https://github.com/damuellen/xlsxwriter.swift", from: "1.0.0"),
+        .package(url: "https://github.com/CoreOffice/CoreXLSX.git", from: "0.9.0"),
+        .package(url: "https://github.com/swiftcsv/SwiftCSV.git", from: "0.6.0")
     ],
     targets: [
         .target(
             name: "NexusFiles",
             dependencies: [
-                .product(name: "xlsxwriter", package: "xlsxwriter.swift")
+                .product(name: "xlsxwriter", package: "xlsxwriter.swift"),
+                "CoreXLSX",
+                "SwiftCSV"
             ],
             path: "Sources",
             resources: [.process("Localization")]
+        ),
+        .executableTarget(
+            name: "NexusFilesMac",
+            dependencies: ["NexusFiles"],
+            path: "MacApp"
         ),
         .target(
             name: "NexusFilesShareExtension",
@@ -42,22 +50,32 @@ let package = Package(
     name: "NexusFiles",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17)
+        .iOS(.v17), .macOS(.v14)
     ],
     products: [
-        .library(name: "NexusFiles", targets: ["NexusFiles"])
+        .library(name: "NexusFiles", targets: ["NexusFiles"]),
+        .executable(name: "NexusFilesMac", targets: ["NexusFilesMac"])
     ],
     dependencies: [
-        .package(url: "https://github.com/damuellen/xlsxwriter.swift", from: "1.0.0")
+        .package(url: "https://github.com/damuellen/xlsxwriter.swift", from: "1.0.0"),
+        .package(url: "https://github.com/CoreOffice/CoreXLSX.git", from: "0.9.0"),
+        .package(url: "https://github.com/swiftcsv/SwiftCSV.git", from: "0.6.0")
     ],
     targets: [
         .target(
             name: "NexusFiles",
             dependencies: [
-                .product(name: "xlsxwriter", package: "xlsxwriter.swift")
+                .product(name: "xlsxwriter", package: "xlsxwriter.swift"),
+                "CoreXLSX",
+                "SwiftCSV"
             ],
             path: "Sources",
             resources: [.process("Localization")]
+        ),
+        .executableTarget(
+            name: "NexusFilesMac",
+            dependencies: ["NexusFiles"],
+            path: "MacApp"
         ),
         .testTarget(
             name: "NexusFilesTests",

--- a/ShareExtension/ShareExtensionStub.swift
+++ b/ShareExtension/ShareExtensionStub.swift
@@ -18,38 +18,84 @@ class ShareViewController: UIViewController {
         if provider.hasItemConformingToTypeIdentifier("public.data") {
             provider.loadInPlaceFileRepresentation(forTypeIdentifier: "public.data") { url, _, _ in
                 if let url {
-                    DispatchQueue.main.async { self.presentSave(for: url) }
+                    DispatchQueue.main.async { self.presentOptions(for: url) }
                 }
             }
         }
     }
 
-    private func presentSave(for url: URL) {
-        let alert = UIAlertController(title: "Import File", message: "Choose Category", preferredStyle: .actionSheet)
+    private func presentOptions(for url: URL) {
+        let alert = UIAlertController(title: "Import File", message: nil, preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: "Tractor Info", style: .default) { _ in self.importTractor(url) })
+        alert.addAction(UIAlertAction(title: "Calibration", style: .default) { _ in self.importCalibration(url) })
+        alert.addAction(UIAlertAction(title: "Recommendation", style: .default) { _ in self.importRecommendation(url) })
         for cat in homeVM.categories {
-            alert.addAction(UIAlertAction(title: cat.name, style: .default) { _ in
-                self.save(url, to: cat)
-            })
+            alert.addAction(UIAlertAction(title: cat.name, style: .default) { _ in self.save(url, to: cat) })
         }
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
-            self.extensionContext?.completeRequest(returningItems: nil)
-        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in self.extensionContext?.completeRequest(returningItems: nil) })
         present(alert, animated: true)
     }
 
     private func save(_ url: URL, to category: Category) {
-        let dest = homeVM.folderURL(for: category.id).appendingPathComponent(url.lastPathComponent)
+        let dest = uniqueURL(for: url, in: category)
         do {
             try FileManager.default.copyItem(at: url, to: dest)
-            homeVM.loadCategories()
+            Task { await homeVM.loadCategories() }
             extensionContext?.completeRequest(returningItems: nil)
         } catch {
-            let err = UIAlertController(title: "Error", message: "Import failed", preferredStyle: .alert)
-            err.addAction(UIAlertAction(title: "OK", style: .default) { _ in
-                self.extensionContext?.completeRequest(returningItems: nil)
-            })
-            present(err, animated: true)
+            showError()
         }
     }
-}
 
+    private func uniqueURL(for url: URL, in category: Category) -> URL {
+        var dest = homeVM.folderURL(for: category.id).appendingPathComponent(url.lastPathComponent)
+        var i = 1
+        while FileManager.default.fileExists(atPath: dest.path) {
+            let name = url.deletingPathExtension().lastPathComponent + "-\(i)"
+            dest = homeVM.folderURL(for: category.id).appendingPathComponent(name).appendingPathExtension(url.pathExtension)
+            i += 1
+        }
+        return dest
+    }
+
+    private func importTractor(_ url: URL) {
+        do {
+            let (pests, weeds) = try DataImporter.parseTractorInfo(url: url)
+            let vm = TractorInfoViewModel()
+            vm.pests.append(contentsOf: pests)
+            vm.weeds.append(contentsOf: weeds)
+            vm.saveDraft()
+            extensionContext?.completeRequest(returningItems: nil)
+        } catch { showError() }
+    }
+
+    private func importCalibration(_ url: URL) {
+        do {
+            let (meta, rows) = try DataImporter.parseCalibration(url: url)
+            let vm = CalibrationViewModel()
+            vm.metadata = meta
+            vm.rows.append(contentsOf: rows)
+            vm.saveDraft()
+            extensionContext?.completeRequest(returningItems: nil)
+        } catch { showError() }
+    }
+
+    private func importRecommendation(_ url: URL) {
+        do {
+            let (meta, rows) = try DataImporter.parseRecommendation(url: url)
+            let vm = RecommendationViewModel()
+            vm.metadata = meta
+            vm.rows.append(contentsOf: rows)
+            vm.saveDraft()
+            extensionContext?.completeRequest(returningItems: nil)
+        } catch { showError() }
+    }
+
+    private func showError() {
+        let err = UIAlertController(title: "Error", message: "Import failed", preferredStyle: .alert)
+        err.addAction(UIAlertAction(title: "OK", style: .default) { _ in
+            self.extensionContext?.completeRequest(returningItems: nil)
+        })
+        present(err, animated: true)
+    }
+}

--- a/Sources/Models/Category.swift
+++ b/Sources/Models/Category.swift
@@ -4,10 +4,12 @@ struct Category: Identifiable, Codable {
     let id: UUID
     var name: String
     var icon: String
+    var color: String
 
-    init(id: UUID = UUID(), name: String, icon: String) {
+    init(id: UUID = UUID(), name: String, icon: String, color: String = "blue") {
         self.id = id
         self.name = name
         self.icon = icon
+        self.color = color
     }
 }

--- a/Sources/Utilities/DataImporter.swift
+++ b/Sources/Utilities/DataImporter.swift
@@ -1,0 +1,179 @@
+import Foundation
+import SwiftCSV
+import CoreXLSX
+
+enum ImportError: Error {
+    case unsupportedFormat
+    case invalidData
+}
+
+struct DataImporter {
+    static func parseTractorInfo(url: URL) throws -> ([PestRow], [WeedRow]) {
+        if url.pathExtension.lowercased() == "csv" {
+            let csv = try CSV(url: url)
+            var pests: [PestRow] = []
+            for row in csv.namedRows {
+                var p = PestRow()
+                p.trekker = row["Trekker"] ?? ""
+                p.rat = row["Rat"] ?? ""
+                p.revs = row["Revs"] ?? ""
+                p.tyd = row["Tyd"] ?? ""
+                p.pomp = row["Pomp"] ?? ""
+                p.druk = row["Druk"] ?? ""
+                pests.append(p)
+            }
+            return (pests, [])
+        } else if url.pathExtension.lowercased() == "xlsx" {
+            guard let file = XLSXFile(filepath: url.path) else { throw ImportError.invalidData }
+            guard let path = try file.parseWorksheetPaths().first,
+                  let sheet = try file.parseWorksheet(at: path) else {
+                throw ImportError.invalidData
+            }
+            var rows: [PestRow] = []
+            for row in sheet.data?.rows.dropFirst() ?? [] { // skip header
+                var r = PestRow()
+                let c = row.cells
+                if c.count >= 6 {
+                    r.trekker = c[0].stringValue ?? ""
+                    r.rat = c[1].stringValue ?? ""
+                    r.revs = c[2].stringValue ?? ""
+                    r.tyd = c[3].stringValue ?? ""
+                    r.pomp = c[4].stringValue ?? ""
+                    r.druk = c[5].stringValue ?? ""
+                }
+                rows.append(r)
+            }
+            return (rows, [])
+        }
+        throw ImportError.unsupportedFormat
+    }
+
+    static func parseCalibration(url: URL) throws -> (CalibrationMetadata, [CalibrationRow]) {
+        if url.pathExtension.lowercased() == "csv" {
+            let csv = try CSV(url: url)
+            var metadata = CalibrationMetadata()
+            var rows: [CalibrationRow] = []
+            if let first = csv.namedRows.first {
+                metadata.producer = first["Produisent"] ?? ""
+                metadata.farm = first["Plaas"] ?? ""
+                metadata.agentName = first["Agent"] ?? ""
+                metadata.crop = first["Gewas"] ?? ""
+            }
+            for row in csv.namedRows.dropFirst() {
+                var r = CalibrationRow()
+                r.trekker = row["Trekker"] ?? ""
+                r.rat = row["Rat"] ?? ""
+                r.revs = row["Revs"] ?? ""
+                r.tyd = row["Tyd"] ?? ""
+                r.pomp = row["Pomp"] ?? ""
+                r.druk = row["Druk"] ?? ""
+                r.aantalSputkoppe = row["Aantal Sputkoppe"] ?? ""
+                r.tipeSputkop = row["Tipe Sputkop"] ?? ""
+                r.lewering = row["Lewering (L/ha)"] ?? ""
+                r.water = row["Water"] ?? ""
+                rows.append(r)
+            }
+            return (metadata, rows)
+        } else if url.pathExtension.lowercased() == "xlsx" {
+            guard let file = XLSXFile(filepath: url.path) else { throw ImportError.invalidData }
+            guard let path = try file.parseWorksheetPaths().first,
+                  let sheet = try file.parseWorksheet(at: path) else { throw ImportError.invalidData }
+            var rows: [CalibrationRow] = []
+            var metadata = CalibrationMetadata()
+            var readingRows = false
+            for (index, row) in (sheet.data?.rows ?? []).enumerated() {
+                if index < 5 {
+                    // metadata rows
+                    let val = row.cells.count > 1 ? row.cells[1].stringValue ?? "" : ""
+                    switch index {
+                    case 0: metadata.producer = val
+                    case 1: metadata.farm = val
+                    case 2: if let d = ISO8601DateFormatter().date(from: val) { metadata.selectedDate = d }
+                    case 3: metadata.agentName = val
+                    case 4: metadata.crop = val
+                    default: break
+                    }
+                } else {
+                    if !readingRows { readingRows = true; continue } // skip header
+                    var r = CalibrationRow()
+                    let c = row.cells
+                    if c.count >= 10 {
+                        r.trekker = c[0].stringValue ?? ""
+                        r.rat = c[1].stringValue ?? ""
+                        r.revs = c[2].stringValue ?? ""
+                        r.tyd = c[3].stringValue ?? ""
+                        r.pomp = c[4].stringValue ?? ""
+                        r.druk = c[5].stringValue ?? ""
+                        r.aantalSputkoppe = c[6].stringValue ?? ""
+                        r.tipeSputkop = c[7].stringValue ?? ""
+                        r.lewering = c[8].stringValue ?? ""
+                        r.water = c[9].stringValue ?? ""
+                    }
+                    rows.append(r)
+                }
+            }
+            return (metadata, rows)
+        }
+        throw ImportError.unsupportedFormat
+    }
+
+    static func parseRecommendation(url: URL) throws -> (RecommendationMetadata, [RecommendationRow]) {
+        if url.pathExtension.lowercased() == "csv" {
+            let csv = try CSV(url: url)
+            var metadata = RecommendationMetadata()
+            var rows: [RecommendationRow] = []
+            if let first = csv.namedRows.first {
+                metadata.farm = first["Plaas"] ?? ""
+                metadata.agentName = first["Agent"] ?? ""
+            }
+            for row in csv.namedRows.dropFirst() {
+                var r = RecommendationRow()
+                r.gewas = row["Gewas"] ?? ""
+                r.teiken = row["Teiken"] ?? ""
+                r.produk = row["Produk"] ?? ""
+                r.aktief = row["Aktief"] ?? ""
+                r.dosis100LT = row["Dosis/100 LT"] ?? ""
+                r.dosisTenK = row["Dosis/Ten K"] ?? ""
+                r.ohp = row["OHP"] ?? ""
+                r.opmerkings = row["Opmerkings"] ?? ""
+                rows.append(r)
+            }
+            return (metadata, rows)
+        } else if url.pathExtension.lowercased() == "xlsx" {
+            guard let file = XLSXFile(filepath: url.path) else { throw ImportError.invalidData }
+            guard let path = try file.parseWorksheetPaths().first,
+                  let sheet = try file.parseWorksheet(at: path) else { throw ImportError.invalidData }
+            var rows: [RecommendationRow] = []
+            var metadata = RecommendationMetadata()
+            var readingRows = false
+            for (index, row) in (sheet.data?.rows ?? []).enumerated() {
+                if index < 3 {
+                    let val = row.cells.count > 1 ? row.cells[1].stringValue ?? "" : ""
+                    switch index {
+                    case 0: metadata.farm = val
+                    case 1: metadata.agentName = val
+                    case 2: if let d = ISO8601DateFormatter().date(from: val) { metadata.selectedDate = d }
+                    default: break
+                    }
+                } else {
+                    if !readingRows { readingRows = true; continue }
+                    var r = RecommendationRow()
+                    let c = row.cells
+                    if c.count >= 8 {
+                        r.gewas = c[0].stringValue ?? ""
+                        r.teiken = c[1].stringValue ?? ""
+                        r.produk = c[2].stringValue ?? ""
+                        r.aktief = c[3].stringValue ?? ""
+                        r.dosis100LT = c[4].stringValue ?? ""
+                        r.dosisTenK = c[5].stringValue ?? ""
+                        r.ohp = c[6].stringValue ?? ""
+                        r.opmerkings = c[7].stringValue ?? ""
+                    }
+                    rows.append(r)
+                }
+            }
+            return (metadata, rows)
+        }
+        throw ImportError.unsupportedFormat
+    }
+}

--- a/Sources/Utilities/QuickLookPreview.swift
+++ b/Sources/Utilities/QuickLookPreview.swift
@@ -1,0 +1,25 @@
+#if canImport(QuickLook)
+import SwiftUI
+import QuickLook
+
+struct QuickLookPreview: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ controller: QLPreviewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(url: url) }
+
+    final class Coordinator: NSObject, QLPreviewControllerDataSource {
+        let url: URL
+        init(url: URL) { self.url = url }
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem { url as NSURL }
+    }
+}
+#endif

--- a/Sources/Views/HomeView.swift
+++ b/Sources/Views/HomeView.swift
@@ -5,9 +5,11 @@ struct HomeView: View {
     @State private var showingAdd = false
     @State private var newName = ""
     @State private var newIcon = "folder"
+    @State private var newColor = "blue"
     @State private var searchText = ""
     @State private var editName = ""
     @State private var editIcon = "folder"
+    @State private var editColor = "blue"
     @State private var editingCategory: Category?
     @State private var showEdit = false
 
@@ -20,7 +22,7 @@ struct HomeView: View {
                             Label(category.name, systemImage: category.icon)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding()
-                                .background(Color.white)
+                                .background(Color(category.color))
                                 .cornerRadius(8)
                                 .shadow(radius: 1)
                         }
@@ -29,18 +31,29 @@ struct HomeView: View {
                                 editingCategory = category
                                 editName = category.name
                                 editIcon = category.icon
+                                editColor = category.color
                                 showEdit = true
                             }
                         }
                     }
+                    .onMove(perform: vm.moveCategory)
                     .onDelete(perform: vm.deleteCategory)
                 }
                 .padding()
             }
             .background(Color.green.opacity(0.1))
             .navigationTitle("NexusFiles".localized)
-            .searchable(text: $searchText, prompt: "Search Categories".localized)
+            .searchable(text: $searchText, prompt: "Search Categories".localized) {
+                if searchText.isEmpty {
+                    ForEach(vm.categories) { cat in
+                        Text(cat.name).searchCompletion(cat.name)
+                    }
+                }
+            }
             .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    EditButton()
+                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { showingAdd = true }) {
                         Image(systemName: "plus.circle.fill")
@@ -57,14 +70,16 @@ struct HomeView: View {
                     Form {
                         TextField("Name".localized, text: $newName)
                         TextField("Icon".localized, text: $newIcon)
+                        TextField("Color".localized, text: $newColor)
                     }
                     .navigationTitle("New Category".localized)
                     .toolbar {
                         ToolbarItem(placement: .navigationBarTrailing) {
                             Button("Add".localized) {
-                                vm.addCategory(name: newName, icon: newIcon)
+                                vm.addCategory(name: newName, icon: newIcon, color: newColor)
                                 newName = ""
                                 newIcon = "folder"
+                                newColor = "blue"
                                 showingAdd = false
                             }
                             .disabled(newName.isEmpty)
@@ -80,13 +95,14 @@ struct HomeView: View {
                     Form {
                         TextField("Name".localized, text: $editName)
                         TextField("Icon".localized, text: $editIcon)
+                        TextField("Color".localized, text: $editColor)
                     }
                     .navigationTitle("Edit Category".localized)
                     .toolbar {
                         ToolbarItem(placement: .navigationBarTrailing) {
                             Button("Save".localized) {
                                 if let id = editingCategory?.id {
-                                    vm.renameCategory(id: id, name: editName, icon: editIcon)
+                                    vm.renameCategory(id: id, name: editName, icon: editIcon, color: editColor)
                                 }
                                 showEdit = false
                             }

--- a/Tests/NexusFilesTests/CategoryPersistenceTests.swift
+++ b/Tests/NexusFilesTests/CategoryPersistenceTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import NexusFiles
+
+final class CategoryPersistenceTests: XCTestCase {
+    func testSaveAndLoadCategories() async throws {
+        let vm = HomeViewModel()
+        vm.addCategory(name: "Test", icon: "folder", color: "red")
+        try await Task.sleep(nanoseconds: 100_000_000)
+        let vm2 = HomeViewModel()
+        await Task.yield()
+        XCTAssert(vm2.categories.contains { $0.name == "Test" })
+        if let idx = vm.categories.firstIndex(where: { $0.name == "Test" }) {
+            vm.deleteCategory(at: IndexSet(integer: idx))
+        }
+    }
+}

--- a/Tests/NexusFilesTests/DataImporterTests.swift
+++ b/Tests/NexusFilesTests/DataImporterTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import NexusFiles
+
+final class DataImporterTests: XCTestCase {
+    func testParseTractorCSV() throws {
+        let data = "Trekker,Rat,Revs,Tyd,Pomp,Druk\nA,1,2,3,4,5"
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("tractor.csv")
+        try data.write(to: url, atomically: true, encoding: .utf8)
+        let (pests, _) = try DataImporter.parseTractorInfo(url: url)
+        XCTAssertEqual(pests.first?.trekker, "A")
+    }
+}


### PR DESCRIPTION
## Summary
- parse CSV/XLSX files with new `DataImporter`
- show previews with QuickLook helper
- store color for every document category
- async file operations and category reordering
- improve CategoryView importing and preview
- color-coded categories and search suggestions on the Home screen
- extend iOS share extension for direct import
- add macOS app target and update package
- test parsing and category persistence

## Testing
- `swift test --enable-test-discovery` *(fails: 'xlsxwriter.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ae727238833191417ca86df3adb3