### PR TITLE
Add Afrikaans categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 NexusFiles is an example SwiftUI 5 application demonstrating how to collect structured data and export it to Microsoft Excel. The app contains three data-entry forms and ships with a stub share extension for importing files.
 
+The interface is localized in Afrikaans and English. The Home screen automatically populates with several folders useful for agricultural documentation such as "Spuitprogramme" and "MRL".
+
 ## Features
 
 - **Tractor Information** – capture pest and weed management data.

--- a/Sources/Localization/af.lproj/Localizable.strings
+++ b/Sources/Localization/af.lproj/Localizable.strings
@@ -19,3 +19,10 @@
 "Aanbeveling" = "Aanbeveling";
 "Upload" = "Oplaai";
 "Destination" = "Bestemming";
+"Spuitprogramme" = "Spuitprogramme";
+"MRL" = "MRL";
+"Etikette" = "Etikette";
+"Kalibrasies" = "Kalibrasies";
+"Aanbevelings" = "Aanbevelings";
+"Gewas Inligting" = "Gewas Inligting";
+

--- a/Sources/Localization/en.lproj/Localizable.strings
+++ b/Sources/Localization/en.lproj/Localizable.strings
@@ -19,3 +19,10 @@
 "Aanbeveling" = "Recommendation";
 "Upload" = "Upload";
 "Destination" = "Destination";
+"Spuitprogramme" = "Spray Programs";
+"MRL" = "MRL";
+"Etikette" = "Labels";
+"Kalibrasies" = "Calibrations";
+"Aanbevelings" = "Recommendations";
+"Gewas Inligting" = "Crop Info";
+

--- a/Sources/Utilities/PDFExporter.swift
+++ b/Sources/Utilities/PDFExporter.swift
@@ -1,0 +1,11 @@
+import Foundation
+import PDFKit
+
+struct PDFExporter {
+    /// Placeholder conversion from Excel to PDF.
+    /// In a real app, implement proper rendering.
+    static func convertExcelToPDF(url: URL) throws -> URL {
+        // TODO: implement actual conversion
+        return url
+    }
+}

--- a/Sources/ViewModels/HomeViewModel.swift
+++ b/Sources/ViewModels/HomeViewModel.swift
@@ -31,9 +31,25 @@ final class HomeViewModel: ObservableObject {
                 return []
             }.value
             categories = loaded.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            if categories.isEmpty {
+                categories = defaultCategories()
+                await saveCategories()
+                for cat in categories { await createFolder(for: cat) }
+            }
         } catch {
             print("Load error: \(error)")
         }
+    }
+
+    private func defaultCategories() -> [Category] {
+        [
+            Category(name: "Spuitprogramme".localized, icon: "doc"),
+            Category(name: "MRL".localized, icon: "doc.text"),
+            Category(name: "Etikette".localized, icon: "tag"),
+            Category(name: "Kalibrasies".localized, icon: "wrench"),
+            Category(name: "Aanbevelings".localized, icon: "list.bullet.rectangle"),
+            Category(name: "Gewas Inligting".localized, icon: "leaf")
+        ]
     }
 
     func saveCategories() async {

--- a/Sources/Views/CategoryView.swift
+++ b/Sources/Views/CategoryView.swift
@@ -64,7 +64,15 @@ struct CategoryView: View {
         }
     }
 
-    private func share(_ url: URL) { shareURL = url }
+    private func share(_ url: URL) {
+        if url.pathExtension.lowercased() == "xlsx" {
+            if let pdfURL = try? PDFExporter.convertExcelToPDF(url: url) {
+                shareURL = pdfURL
+                return
+            }
+        }
+        shareURL = url
+    }
 
     private func uniqueURL(for url: URL) -> URL {
         var dest = baseURL.appendingPathComponent(url.lastPathComponent)


### PR DESCRIPTION
## Summary
- localize new Afrikaans category names
- create default folders for agricultural docs
- stub out PDF export and share as PDF for spreadsheets
- mention localization in README

## Testing
- `swift test` *(fails: xlsxwriter.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840b12f4d348331831748fe03b1b1c8