### PR TITLE
Improve logging and category handling

### DIFF
--- a/Sources/Utilities/ExcelExporter.swift
+++ b/Sources/Utilities/ExcelExporter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import xlsxwriter
+import os
 
 struct ExcelExporter {
     static func isoDateString(_ date: Date = Date()) -> String {
@@ -28,6 +29,7 @@ struct ExcelExporter {
               headers: ["Trekker", "Rat", "Revs", "Tyd oor toetsafstand", "Pomp", "Druk"],
               to: &worksheet)
 
+        Log.general.info("Excel saved to \(fileURL.path, privacy: .public)")
         return fileURL
     }
 
@@ -68,6 +70,7 @@ struct ExcelExporter {
             rowIndex += 1
         }
 
+        Log.general.info("Excel saved to \(fileURL.path, privacy: .public)")
         return fileURL
     }
 
@@ -102,6 +105,7 @@ struct ExcelExporter {
             rowIndex += 1
         }
 
+        Log.general.info("Excel saved to \(fileURL.path, privacy: .public)")
         return fileURL
     }
 

--- a/Sources/Utilities/FileStorage.swift
+++ b/Sources/Utilities/FileStorage.swift
@@ -1,11 +1,16 @@
 import Foundation
 
+/// Logging helper
+import os
+
 /// Simple utility for loading and saving Codable values to disk.
 struct FileStorage {
     /// Load a Codable value from a file URL.
     static func load<T: Decodable>(_ type: T.Type, from url: URL) throws -> T {
         let data = try Data(contentsOf: url)
-        return try JSONDecoder().decode(T.self, from: data)
+        let value = try JSONDecoder().decode(T.self, from: data)
+        Log.general.debug("Loaded \(url.lastPathComponent, privacy: .public)")
+        return value
     }
 
     /// Save a Codable value to a file URL.
@@ -13,5 +18,6 @@ struct FileStorage {
         let data = try JSONEncoder().encode(value)
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try data.write(to: url, options: .atomic)
+        Log.general.debug("Saved \(url.lastPathComponent, privacy: .public)")
     }
 }

--- a/Sources/Utilities/Logging.swift
+++ b/Sources/Utilities/Logging.swift
@@ -1,0 +1,5 @@
+import os
+
+enum Log {
+    static let general = Logger(subsystem: "com.nexusfiles.app", category: "General")
+}

--- a/Sources/ViewModels/HomeViewModel.swift
+++ b/Sources/ViewModels/HomeViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import os
 
 /// Manages the list of categories shown on the Home screen and handles
 /// persistence of category metadata and folders.
@@ -68,6 +69,10 @@ final class HomeViewModel: ObservableObject {
     }
 
     func addCategory(name: String, icon: String, color: String = "blue") {
+        guard !categories.contains(where: { $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame }) else {
+            Log.general.info("Category \(name, privacy: .public) already exists")
+            return
+        }
         let category = Category(name: name, icon: icon, color: color)
         categories.append(category)
         categories.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }

--- a/Tests/NexusFilesTests/CategoryPersistenceTests.swift
+++ b/Tests/NexusFilesTests/CategoryPersistenceTests.swift
@@ -13,4 +13,15 @@ final class CategoryPersistenceTests: XCTestCase {
             vm.deleteCategory(at: IndexSet(integer: idx))
         }
     }
+
+    func testAddDuplicateCategoryDoesNotCreateDuplicate() throws {
+        let vm = HomeViewModel()
+        vm.addCategory(name: "Dup", icon: "folder")
+        vm.addCategory(name: "Dup", icon: "folder")
+        let count = vm.categories.filter { $0.name == "Dup" }.count
+        XCTAssertEqual(count, 1)
+        if let idx = vm.categories.firstIndex(where: { $0.name == "Dup" }) {
+            vm.deleteCategory(at: IndexSet(integer: idx))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a simple logger helper
- log loading/saving in `FileStorage`
- log exported files in `ExcelExporter`
- prevent duplicate categories in `HomeViewModel`
- test duplicate category logic

## Testing
- `swift test --enable-test-discovery` *(fails: could not build `xlsxwriter` due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840b58cad8883319d13b7cdaafc2010