### PR TITLE
Improve build portability and CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,16 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: swift-actions/setup-swift@v1
+      - name: Install libxlsxwriter
+        run: brew install libxlsxwriter
+      - name: Build and test
+        run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:5.9
 import PackageDescription
 
-#if os(iOS)
+#if os(Linux)
 let package = Package(
     name: "NexusFiles",
     defaultLocalization: "en",
@@ -13,7 +13,6 @@ let package = Package(
         .executable(name: "NexusFilesMac", targets: ["NexusFilesMac"])
     ],
     dependencies: [
-        .package(url: "https://github.com/damuellen/xlsxwriter.swift", from: "1.0.0"),
         .package(url: "https://github.com/CoreOffice/CoreXLSX.git", from: "0.9.0"),
         .package(url: "https://github.com/swiftcsv/SwiftCSV.git", from: "0.6.0")
     ],
@@ -21,7 +20,6 @@ let package = Package(
         .target(
             name: "NexusFiles",
             dependencies: [
-                .product(name: "xlsxwriter", package: "xlsxwriter.swift"),
                 "CoreXLSX",
                 "SwiftCSV"
             ],
@@ -32,11 +30,6 @@ let package = Package(
             name: "NexusFilesMac",
             dependencies: ["NexusFiles"],
             path: "MacApp"
-        ),
-        .target(
-            name: "NexusFilesShareExtension",
-            dependencies: ["NexusFiles"],
-            path: "ShareExtension"
         ),
         .testTarget(
             name: "NexusFilesTests",
@@ -76,6 +69,11 @@ let package = Package(
             name: "NexusFilesMac",
             dependencies: ["NexusFiles"],
             path: "MacApp"
+        ),
+        .target(
+            name: "NexusFilesShareExtension",
+            dependencies: ["NexusFiles"],
+            path: "ShareExtension"
         ),
         .testTarget(
             name: "NexusFilesTests",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ The app presents three tabs—Tractor Information, Calibration, and Recommendati
 
 Building on Linux requires the `libxlsxwriter` development package. However, the share extension uses UIKit, which is not available on Linux, so building the `NexusFilesShareExtension` target will fail. Use macOS with Xcode for the complete experience.
 
+### Continuous Integration
+
+GitHub Actions automatically run `swift test` for all pushes and pull requests using macOS runners. See `.github/workflows/swift.yml` for details.
+
 ## Exporting Data
 
 The exported Excel files are saved to the app's documents directory. Each file name includes an ISO‑8601 timestamp for easy organization. Files can be shared directly from the app using the standard iOS share sheet.

--- a/Sources/Utilities/ExcelExporter.swift
+++ b/Sources/Utilities/ExcelExporter.swift
@@ -1,6 +1,12 @@
 import Foundation
-import xlsxwriter
 import os
+#if canImport(xlsxwriter)
+import xlsxwriter
+#endif
+
+enum ExcelExporterError: Error {
+    case libraryUnavailable
+}
 
 struct ExcelExporter {
     static func isoDateString(_ date: Date = Date()) -> String {
@@ -14,6 +20,7 @@ struct ExcelExporter {
         return docs.appendingPathComponent(filename)
     }
 
+#if canImport(xlsxwriter)
     static func exportTractorInfo(pestRows: [PestRow], weedRows: [WeedRow]) throws -> URL {
         let fileURL = documentsURL(filename: "NexusFiles_TractorInfo_\(isoDateString()).xlsx")
         let workbook = Workbook(fileURL.path)
@@ -73,7 +80,6 @@ struct ExcelExporter {
         Log.general.info("Excel saved to \(fileURL.path, privacy: .public)")
         return fileURL
     }
-
     static func exportRecommendation(metadata: RecommendationMetadata, rows: [RecommendationRow]) throws -> URL {
         let fileURL = documentsURL(filename: "NexusFiles_Recommendation_\(isoDateString()).xlsx")
         let workbook = Workbook(fileURL.path)
@@ -119,6 +125,19 @@ struct ExcelExporter {
             }
         }
     }
+#else
+    static func exportTractorInfo(pestRows: [PestRow], weedRows: [WeedRow]) throws -> URL {
+        throw ExcelExporterError.libraryUnavailable
+    }
+
+    static func exportCalibration(metadata: CalibrationMetadata, rows: [CalibrationRow]) throws -> URL {
+        throw ExcelExporterError.libraryUnavailable
+    }
+
+    static func exportRecommendation(metadata: RecommendationMetadata, rows: [RecommendationRow]) throws -> URL {
+        throw ExcelExporterError.libraryUnavailable
+    }
+#endif
 }
 
 struct ActivityView: UIViewControllerRepresentable {


### PR DESCRIPTION
## Summary
- make Package.swift compile on Linux by skipping xlsxwriter
- provide graceful error when xlsxwriter is missing
- add CI workflow
- document CI setup in README

## Testing
- `swift test -l` *(fails: ZIPFoundation build error)*

------
https://chatgpt.com/codex/tasks/task_e_6840bcee4f5c8331aa04e8d057c8c219