### PR TITLE
Improve category rename behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The interface is presented in English. The Home screen automatically populates w
 - **Recommendation** – create chemical recommendation lists.
 - **Excel Export** – generate `.xlsx` files using [xlsxwriter.swift](https://github.com/damuellen/xlsxwriter.swift).
 - **Share Extension Stub** – placeholder for handling incoming Excel or CSV files.
-- **Home File Manager** – organize documents into categories, rename them, and quickly locate folders using search from a green-themed home screen.
+ - **Home File Manager** – organize documents into categories, rename them (with duplicate name protection), and quickly locate folders using search from a green-themed home screen.
 
 ## Requirements
 

--- a/Sources/ViewModels/HomeViewModel.swift
+++ b/Sources/ViewModels/HomeViewModel.swift
@@ -93,6 +93,11 @@ final class HomeViewModel: ObservableObject {
 
     func renameCategory(id: UUID, name: String, icon: String, color: String) {
         guard let index = categories.firstIndex(where: { $0.id == id }) else { return }
+        // Prevent renaming to an existing category name (case-insensitive)
+        guard !categories.contains(where: { $0.id != id && $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame }) else {
+            Log.general.info("Category \(name, privacy: .public) already exists")
+            return
+        }
         categories[index].name = name
         categories[index].icon = icon
         categories[index].color = color

--- a/Tests/NexusFilesTests/CategoryPersistenceTests.swift
+++ b/Tests/NexusFilesTests/CategoryPersistenceTests.swift
@@ -24,4 +24,22 @@ final class CategoryPersistenceTests: XCTestCase {
             vm.deleteCategory(at: IndexSet(integer: idx))
         }
     }
+
+    func testRenamingToExistingCategoryIsIgnored() throws {
+        let vm = HomeViewModel()
+        vm.addCategory(name: "One", icon: "folder")
+        vm.addCategory(name: "Two", icon: "folder")
+        if let id = vm.categories.first(where: { $0.name == "Two" })?.id {
+            vm.renameCategory(id: id, name: "One", icon: "folder", color: "blue")
+        }
+        let count = vm.categories.filter { $0.name == "One" }.count
+        XCTAssertEqual(count, 1)
+        // Cleanup
+        if let idx = vm.categories.firstIndex(where: { $0.name == "One" }) {
+            vm.deleteCategory(at: IndexSet(integer: idx))
+        }
+        if let idx = vm.categories.firstIndex(where: { $0.name == "Two" }) {
+            vm.deleteCategory(at: IndexSet(integer: idx))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- prevent duplicate names when renaming categories
- update tests for category rename validation
- document the new rename behavior in the README

## Testing
- `swift test -l` *(fails: Archive+MemoryFile.swift compile error)*

------
https://chatgpt.com/codex/tasks/task_e_6840c514aa08833199488b0161dbead7