### PR TITLE
Update xlsxwriter.swift dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         .executable(name: "NexusFilesMac", targets: ["NexusFilesMac"])
     ],
     dependencies: [
-        .package(url: "https://github.com/damuellen/xlsxwriter.swift", from: "1.0.0"),
+        .package(url: "https://github.com/damuellen/xlsxwriter.swift", branch: "main"),
         .package(url: "https://github.com/CoreOffice/CoreXLSX.git", from: "0.9.0"),
         .package(url: "https://github.com/swiftcsv/SwiftCSV.git", from: "0.6.0")
     ],

--- a/README.md
+++ b/README.md
@@ -18,17 +18,12 @@ The interface is presented in English. The Home screen automatically populates w
 - macOS 14 or later
 - Xcode 17.3
 - iOS 17 SDK
-- [Libxlsxwriter](https://libxlsxwriter.github.io/getting_started.html) installed on your system
 
 ## Getting Started
 
 1. Clone this repository.
-2. Install libxlsxwriter using Homebrew:
-   ```bash
-   brew install libxlsxwriter
-   ```
-3. Open `Package.swift` in Xcode 17.3 or newer.
-4. Build and run the `NexusFiles` target on an iOS 17 simulator or device.
+2. Open `Package.swift` in Xcode 17.3 or newer.
+3. Build and run the `NexusFiles` target on an iOS 17 simulator or device.
 
 To run the unit tests in Xcode select **Product ▸ Test** or run `swift test` from
 the command line (requires the dependencies above).
@@ -37,7 +32,7 @@ The app presents three tabs—Tractor Information, Calibration, and Recommendati
 
 ### Running on Linux
 
-Building on Linux requires the `libxlsxwriter` development package. However, the share extension uses UIKit, which is not available on Linux, so building the `NexusFilesShareExtension` target will fail. Use macOS with Xcode for the complete experience.
+On Linux the `libxlsxwriter` C library is built automatically via Swift Package Manager. The share extension uses UIKit, which is unavailable on Linux, so building the `NexusFilesShareExtension` target will fail. Use macOS with Xcode for the complete experience.
 
 ## Exporting Data
 


### PR DESCRIPTION
## Summary
- use the main branch of xlsxwriter.swift so libxlsxwriter builds automatically
- update README accordingly

## Testing
- `swift build`
- `swift test` *(fails: value of optional type 'UnsafeMutablePointer<FILE>?')*

------
https://chatgpt.com/codex/tasks/task_e_6840cf4cfac88331b310936328e03fbc