### PR TITLE
Refactor draft persistence

### DIFF
--- a/Sources/Utilities/DraftStorage.swift
+++ b/Sources/Utilities/DraftStorage.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// A helper for loading and saving draft data locally and to iCloud if available.
+struct DraftStorage<T: Codable> {
+    private let fileManager = FileManager.default
+    let localURL: URL
+    let iCloudURL: URL?
+
+    init(fileName: String) {
+        self.localURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(fileName)
+        if let cloud = fileManager.url(forUbiquityContainerIdentifier: nil) {
+            self.iCloudURL = cloud.appendingPathComponent(fileName)
+        } else {
+            self.iCloudURL = nil
+        }
+    }
+
+    func load() -> T? {
+        do {
+            if fileManager.fileExists(atPath: localURL.path) {
+                return try FileStorage.load(T.self, from: localURL)
+            }
+            if let cloud = iCloudURL, fileManager.fileExists(atPath: cloud.path) {
+                return try FileStorage.load(T.self, from: cloud)
+            }
+        } catch {
+            print("Draft load error: \(error)")
+        }
+        return nil
+    }
+
+    func save(_ value: T) {
+        do {
+            try FileStorage.save(value, to: localURL)
+            if let cloud = iCloudURL { try FileStorage.save(value, to: cloud) }
+        } catch {
+            print("Draft save error: \(error)")
+        }
+    }
+
+    func clear() {
+        try? fileManager.removeItem(at: localURL)
+        if let cloud = iCloudURL { try? fileManager.removeItem(at: cloud) }
+    }
+}

--- a/Sources/ViewModels/CalibrationViewModel.swift
+++ b/Sources/ViewModels/CalibrationViewModel.swift
@@ -6,13 +6,7 @@ final class CalibrationViewModel: ObservableObject {
     @Published var rows: [CalibrationRow] = []
     @Published var shareURL: URL?
 
-    private var draftURL: URL {
-        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("CalibrationDraft.json")
-    }
-    private var iCloudURL: URL? {
-        FileManager.default.url(forUbiquityContainerIdentifier: nil)?.appendingPathComponent("CalibrationDraft.json")
-    }
+    private let storage = DraftStorage<Draft>(fileName: "CalibrationDraft.json")
 
     struct Draft: Codable {
         var metadata: CalibrationMetadata
@@ -29,35 +23,28 @@ final class CalibrationViewModel: ObservableObject {
     func saveToExcel() {
         do {
             shareURL = try ExcelExporter.exportCalibration(metadata: metadata, rows: rows)
-            try FileStorage.save(Draft(metadata: metadata, rows: rows), to: draftURL)
+            storage.save(Draft(metadata: metadata, rows: rows))
         } catch {
             print("Save error: \(error)")
         }
     }
 
     func saveDraft() {
-        try? FileStorage.save(Draft(metadata: metadata, rows: rows), to: draftURL)
-        if let cloud = iCloudURL { try? FileStorage.save(Draft(metadata: metadata, rows: rows), to: cloud) }
+        storage.save(Draft(metadata: metadata, rows: rows))
     }
 
     func shareFile() { if shareURL == nil { saveToExcel() } }
 
     func clearDraft() {
-        try? FileManager.default.removeItem(at: draftURL)
-        if let cloud = iCloudURL { try? FileManager.default.removeItem(at: cloud) }
+        storage.clear()
         metadata = CalibrationMetadata()
         rows.removeAll()
     }
 
     private func loadDraft() {
-        do {
-            if FileManager.default.fileExists(atPath: draftURL.path) {
-                let draft = try FileStorage.load(Draft.self, from: draftURL)
-                metadata = draft.metadata
-                rows = draft.rows
-            }
-        } catch {
-            print("Load error: \(error)")
+        if let draft = storage.load() {
+            metadata = draft.metadata
+            rows = draft.rows
         }
     }
 }


### PR DESCRIPTION
## Summary
- centralize persistence logic for view model drafts with `DraftStorage`
- update TractorInfo, Calibration and Recommendation view models to use the new storage helper

## Testing
- `swift test -q` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684164b60f28833193872f82a37bc5f5