### PR TITLE
Show item counts on Home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NexusFiles 2025
 
-NexusFiles 2025 showcases a SwiftUI 6 workflow for collecting structured data and exporting it to Microsoft Excel. The app contains three data-entry forms and includes a share extension for importing files.
+NexusFiles 2025 showcases a SwiftUI 6 workflow for collecting structured data and exporting it to Microsoft Excel. The app contains three data-entry forms and includes a share extension for importing files. While a minimal macOS build and CLI are provided, the primary experience is designed for iPhone.
 
 The interface is presented in English. The Home screen automatically populates with folders useful for agricultural documentation such as "Spray Programs" and "MRL".
 
@@ -12,6 +12,7 @@ The interface is presented in English. The Home screen automatically populates w
 - **Excel Export** – generate `.xlsx` files using [xlsxwriter.swift](https://github.com/damuellen/xlsxwriter.swift).
 - **Share Extension Stub** – placeholder for handling incoming Excel or CSV files.
 - **Home File Manager** – organize documents into categories, rename them (with duplicate name protection), and quickly locate folders using search from a green-themed home screen.
+- **Category Counts** – each folder on the Home screen now shows how many documents it contains.
 
 ## Requirements
 

--- a/Sources/ViewModels/HomeViewModel.swift
+++ b/Sources/ViewModels/HomeViewModel.swift
@@ -118,6 +118,18 @@ final class HomeViewModel: ObservableObject {
         categoriesURL.appendingPathComponent(id.uuidString)
     }
 
+    /// Returns the number of files stored in the given category's folder.
+    /// Hidden files are ignored so the count matches what users see in the app.
+    func itemCount(for category: Category) -> Int {
+        let url = folderURL(for: category.id)
+        let contents = try? FileManager.default.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        return contents?.count ?? 0
+    }
+
     private func createFolder(for category: Category) async {
         do {
             let url = folderURL(for: category)

--- a/Sources/Views/HomeView.swift
+++ b/Sources/Views/HomeView.swift
@@ -29,7 +29,7 @@ struct HomeView: View {
                 LazyVStack(spacing: 16) {
                     ForEach(vm.categories.filter { searchText.isEmpty || $0.name.localizedCaseInsensitiveContains(searchText) }) { category in
                         NavigationLink(destination: CategoryView(category: category, baseURL: vm.folderURL(for: category.id))) {
-                            Label(category.name, systemImage: category.icon)
+                            Label("\(category.name) (\(vm.itemCount(for: category)))", systemImage: category.icon)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding()
                                 .background(Color(category.color))

--- a/Tests/NexusFilesTests/CategoryPersistenceTests.swift
+++ b/Tests/NexusFilesTests/CategoryPersistenceTests.swift
@@ -42,4 +42,22 @@ final class CategoryPersistenceTests: XCTestCase {
             vm.deleteCategory(at: IndexSet(integer: idx))
         }
     }
+
+    func testItemCountMatchesFiles() async throws {
+        let vm = HomeViewModel()
+        vm.addCategory(name: "CountTest", icon: "folder")
+        try await Task.sleep(nanoseconds: 100_000_000)
+        guard let cat = vm.categories.first(where: { $0.name == "CountTest" }) else {
+            XCTFail("Category not found")
+            return
+        }
+        let fileURL = vm.folderURL(for: cat.id).appendingPathComponent("dummy.txt")
+        FileManager.default.createFile(atPath: fileURL.path, contents: Data())
+        await Task.yield()
+        XCTAssertEqual(vm.itemCount(for: cat), 1)
+        try? FileManager.default.removeItem(at: fileURL)
+        if let idx = vm.categories.firstIndex(where: { $0.id == cat.id }) {
+            vm.deleteCategory(at: IndexSet(integer: idx))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- show how many documents are stored in each category
- update README to mention the iPhone focus and new category counts
- add unit test verifying item counts

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68416872db488331a2e7d8e88cfce0df