### PR TITLE
Add architecture documentation

### DIFF
--- a/Docs/ARCHITECTURE.md
+++ b/Docs/ARCHITECTURE.md
@@ -1,0 +1,37 @@
+# NexusFiles Architecture
+
+This document describes the high level structure of the project. NexusFiles is split into multiple modules to keep the core logic reusable across the macOS app, iOS app and command line utilities.
+
+## Modules
+
+- **NexusFiles** – Swift package containing models, view models and utilities that implement the app logic.
+- **NexusFilesMac** – A minimal macOS application built with SwiftUI that depends on `NexusFiles`.
+- **NexusFilesCLI** – Command line tool for generating Excel files using `swift-argument-parser`.
+- **NexusFilesShareExtension** – Share extension target for importing Excel or CSV files.
+
+## Source Layout
+
+```
+Sources/
+├─ ContentView.swift       – Root container for the iOS interface
+├─ Models/                – Codable data structures
+├─ ViewModels/            – Observable objects that manage state
+├─ Views/                 – SwiftUI views
+├─ Utilities/             – Helper extensions and cross‑platform utilities
+└─ Localization/          – Translated strings
+```
+
+Each feature uses the **Model–View–ViewModel (MVVM)** pattern. Models contain persistent data, view models expose observable state and business logic, and views bind to the view models using SwiftUI.
+
+The directory names mirror the target names declared in `Package.swift` so Swift Package Manager can build the modules without additional configuration.
+
+## Folder Organization
+
+Additional entry points live at the repository root:
+
+- `CLI/` – Sources for the command line tool
+- `MacApp/` – The macOS application wrapper
+- `ShareExtension/` – Share extension code (compiled only on iOS)
+- `Tests/` – Unit tests for the main module
+
+This layout keeps the main app logic independent from the platform‑specific code, making it easier to maintain and extend.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The interface is presented in English. The Home screen automatically populates w
 - **Home File Manager** – organize documents into categories, rename them (with duplicate name protection), and quickly locate folders using search from a green-themed home screen.
 - **Category Counts** – each folder on the Home screen now shows how many documents it contains.
 
+## Architecture
+
+The project follows a modular MVVM design. Core models, view models and helper utilities live in the `Sources` directory and are shared by the macOS app, iOS app and command line tool. Each feature is split into `Models`, `ViewModels` and `Views` to keep UI and data logic separate. Additional entry points such as the CLI and share extension reside at the repository root.
+
+See [Docs/ARCHITECTURE.md](Docs/ARCHITECTURE.md) for a detailed overview of the folder layout and Swift Package targets.
+
 ## Requirements
 
 - macOS 15 or later


### PR DESCRIPTION
## Summary
- document project structure in new `Docs/ARCHITECTURE.md`
- link the architecture overview from `README`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684169e8ff9483318260b551b28a9c91