### PR TITLE
Add CLI subcommand for Excel-to-PDF conversion

### DIFF
--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -5,7 +5,7 @@ import NexusFiles
 struct NexusFilesCLI: ParsableCommand {
     static var configuration = CommandConfiguration(
         abstract: "Command line tools for NexusFiles",
-        subcommands: [ExportTractorInfo.self, ExportCalibration.self, ExportRecommendation.self])
+        subcommands: [ExportTractorInfo.self, ExportCalibration.self, ExportRecommendation.self, ConvertPDF.self])
 }
 
 struct ExportTractorInfo: ParsableCommand {
@@ -56,5 +56,17 @@ struct ExportRecommendation: ParsableCommand {
         let rows = try decoder.decode([RecommendationRow].self, from: Data(contentsOf: URL(fileURLWithPath: rowsFile)))
         let url = try ExcelExporter.exportRecommendation(metadata: metaData, rows: rows)
         print("Excel exported to \(url.path)")
+    }
+}
+
+struct ConvertPDF: ParsableCommand {
+    static var configuration = CommandConfiguration(abstract: "Convert Excel file to PDF")
+
+    @Argument(help: "Path to Excel file")
+    var excel: String
+
+    func run() throws {
+        let url = try PDFExporter.convertExcelToPDF(url: URL(fileURLWithPath: excel))
+        print("PDF exported to \(url.path)")
     }
 }

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ swift run nexusfiles export-calibration meta.json rows.json
 
 Replace `export-calibration` with `export-tractor-info` or `export-recommendation` for the other form types. Each command prints the path to the generated Excel file.
 
+To convert an existing Excel file to a PDF you can run:
+
+```bash
+swift run nexusfiles convert-pdf MySheet.xlsx
+```
+
+The command copies `MySheet.xlsx` to a new `.pdf` file at the same location.
+
 ## Contributing
 
 Contributions are welcome. Please open issues or pull requests on GitHub. All code is expected to follow Swift style conventions and include clear commit messages.


### PR DESCRIPTION
## Summary
- add a new `convert-pdf` command to CLI
- document PDF conversion command in README

## Testing
- `swift test -l` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68417b5f7884833191e2c2aa84e8b5f2