### PR TITLE
Fix build errors and add Excel editor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
     name: "NexusFiles",
     defaultLocalization: "en",
     platforms: [
-        .iOS("19"), .macOS("15")
+        .iOS("13"), .macOS("15")
     ],
     products: [
         .library(name: "NexusFiles", targets: ["NexusFiles"]),

--- a/Sources/Utilities/ExcelExporter.swift
+++ b/Sources/Utilities/ExcelExporter.swift
@@ -1,5 +1,7 @@
 import Foundation
 import os
+import SwiftUI
+import UIKit
 
 struct ExcelExporter {
     static func isoDateString(_ date: Date = Date()) -> String {

--- a/Sources/Views/CategoryView.swift
+++ b/Sources/Views/CategoryView.swift
@@ -8,6 +8,7 @@ struct CategoryView: View {
     @State private var importURL: URL?
     @State private var shareURL: URL?
     @State private var previewURL: URL?
+    @State private var editURL: URL?
     @State private var isSaving = false
 
     var body: some View {
@@ -18,8 +19,9 @@ struct CategoryView: View {
                     Text(url.lastPathComponent)
                         .onTapGesture {
                             if !url.hasDirectoryPath {
-                                if url.pathExtension.lowercased() == "xlsx",
-                                   let pdf = try? PDFExporter.convertExcelToPDF(url: url) {
+                                if url.pathExtension.lowercased() == "xlsx" {
+                                    editURL = url
+                                } else if let pdf = try? PDFExporter.convertExcelToPDF(url: url) {
                                     previewURL = pdf
                                 } else {
                                     previewURL = url
@@ -52,6 +54,7 @@ struct CategoryView: View {
         }
         .sheet(item: $shareURL) { url in ActivityView(activityItems: [url]) }
         .sheet(item: $previewURL) { url in QuickLookPreview(url: url) }
+        .sheet(item: $editURL) { url in SpreadsheetEditorView(url: url) }
         .overlay(Group { if isSaving { ProgressView().progressViewStyle(.circular) } })
     }
 

--- a/Sources/Views/SpreadsheetEditorView.swift
+++ b/Sources/Views/SpreadsheetEditorView.swift
@@ -1,0 +1,88 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import CoreXLSX
+
+/// A simple Excel spreadsheet editor for `.xlsx` files.
+struct SpreadsheetEditorView: View {
+    let url: URL
+    @State private var rows: [[String]] = []
+    @Environment(\.dismiss) private var dismiss
+    @State private var loading = true
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if loading {
+                    ProgressView()
+                } else {
+                    List {
+                        ForEach(rows.indices, id: \.__self) { rowIndex in
+                            HStack {
+                                ForEach(rows[rowIndex].indices, id: \.__self) { colIndex in
+                                    TextField("", text: Binding(
+                                        get: { rows[rowIndex][colIndex] },
+                                        set: { rows[rowIndex][colIndex] = $0 }
+                                    ))
+                                    .textFieldStyle(.roundedBorder)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle(url.lastPathComponent)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Upload") { Task { await upload() } }
+                }
+            }
+            .task { await load() }
+        }
+    }
+
+    private func load() async {
+        guard url.pathExtension.lowercased() == "xlsx" else { loading = false; return }
+        do {
+            guard let file = XLSXFile(filepath: url.path) else { return }
+            guard let path = try file.parseWorksheetPaths().first,
+                  let sheet = try file.parseWorksheet(at: path) else { return }
+            var tmp: [[String]] = []
+            for row in sheet.data?.rows ?? [] {
+                tmp.append(row.cells.map { $0.stringValue ?? "" })
+            }
+            rows = tmp
+        } catch {
+            print("Parse error: \(error)")
+        }
+        loading = false
+    }
+
+    /// Upload the edited spreadsheet to a remote server.
+    private func upload() async {
+        let csv = rows.map { $0.joined(separator: ",") }.joined(separator: "\n")
+        guard let data = csv.data(using: .utf8),
+              let uploadURL = URL(string: "https://example.com/upload") else { return }
+        var request = URLRequest(url: uploadURL)
+        request.httpMethod = "POST"
+        let boundary = "Boundary-\(UUID().uuidString)"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.httpBody = multipartBody(boundary: boundary, data: data, fileName: url.lastPathComponent)
+        do {
+            _ = try await URLSession.shared.data(for: request)
+            dismiss()
+        } catch {
+            print("Upload error: \(error)")
+        }
+    }
+
+    private func multipartBody(boundary: String, data: Data, fileName: String) -> Data {
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(fileName)\"\r\n\r\n".data(using: .utf8)!)
+        body.append(data)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        return body
+    }
+}
+#endif
+


### PR DESCRIPTION
## Summary
- import SwiftUI/UIKit in Excel exporter so `UIViewControllerRepresentable` works
- lower iOS deployment target to 13
- let CategoryView open new SpreadsheetEditorView for `.xlsx` files
- implement minimal SpreadsheetEditorView to edit and upload spreadsheets

## Testing
- `swift test --enable-code-coverage` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6842091c868c833183e32359689310ca