### PR TITLE
Remove ZIPFoundation dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,7 @@ var targets: [Target] = [
         name: "NexusFiles",
         dependencies: [
             "CoreXLSX",
-            "SwiftCSV",
-            "ZIPFoundation"
+            "SwiftCSV"
         ],
         path: "Sources",
         resources: [.process("Localization")]
@@ -41,7 +40,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/CoreOffice/CoreXLSX.git", from: "0.9.0"),
         .package(url: "https://github.com/swiftcsv/SwiftCSV.git", from: "0.6.0"),
-        .package(url: "https://github.com/weichsel/ZIPFoundation.git", branch: "feature/swift6")
     ],
     targets: targets
 )


### PR DESCRIPTION
## Summary
- remove ZIPFoundation from package dependencies and targets

## Testing
- `swift build` *(fails: value of optional type in ZIPFoundation must be unwrapped)*

------
https://chatgpt.com/codex/tasks/task_e_684213b83fe8833187d89caab188a8e4