### PR TITLE
Add upload endpoint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Categories created on the Home screen are saved as JSON in the app's documents d
 
 If iCloud is available, NexusFiles 2025 copies saved categories and form drafts to your iCloud container so data is shared across your devices. Ensure you are logged into iCloud before running the app.
 
+### Upload Endpoint
+
+The spreadsheet editor uploads files to a server. Set the `NEXUSFILES_UPLOAD_ENDPOINT` environment variable (or define `NexusFilesUploadEndpoint` in the app's Info.plist) to override the default `https://example.com/upload` endpoint.
+
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- allow configuring the spreadsheet upload destination
- read the endpoint from an environment variable or Info.plist
- document how to set the upload URL

## Testing
- `swift test -l` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684213bb4fd48331aa40e9985621fe68