### PR TITLE
Add UniqueURL collision test

### DIFF
--- a/Sources/Views/CategoryView.swift
+++ b/Sources/Views/CategoryView.swift
@@ -87,7 +87,7 @@ struct CategoryView: View {
         shareURL = url
     }
 
-    private func uniqueURL(for url: URL) -> URL {
+    func uniqueURL(for url: URL) -> URL {
         var dest = baseURL.appendingPathComponent(url.lastPathComponent)
         var counter = 1
         while FileManager.default.fileExists(atPath: dest.path) {

--- a/Tests/NexusFilesTests/UniqueURLTests.swift
+++ b/Tests/NexusFilesTests/UniqueURLTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import NexusFiles
+
+final class UniqueURLTests: XCTestCase {
+    func testUniqueURLAddsIncrement() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let category = Category(name: "Temp", icon: "doc")
+        var view = CategoryView(category: category, baseURL: tempDir)
+        let original = tempDir.appendingPathComponent("file.txt")
+        FileManager.default.createFile(atPath: original.path, contents: Data())
+
+        let first = view.uniqueURL(for: original)
+        XCTAssertEqual(first.lastPathComponent, "file-1.txt")
+        FileManager.default.createFile(atPath: first.path, contents: Data())
+
+        let second = view.uniqueURL(for: original)
+        XCTAssertEqual(second.lastPathComponent, "file-2.txt")
+    }
+}


### PR DESCRIPTION
## Summary
- expose `uniqueURL(for:)` in `CategoryView`
- add `UniqueURLTests` verifying incremented suffixes on collision

## Testing
- `swift test --enable-code-coverage` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684213bdd34483319d6ebae5fdd35ee7